### PR TITLE
Preventing a crash when not connected to the production app.

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -11,14 +11,15 @@
     "postinstall": "patch-package"
   },
   "dependencies": {
+    "@react-native-async-storage/async-storage": "https://github.com/blitzstudios/async-storage.git#release/1.1",
     "@react-native-community/netinfo": "^9.3.7",
+    "axios": "0.15.3",
+    "lodash": "4.17.21",
     "react": "17.0.2",
     "react-native": "0.66.5",
-    "react-native-udp": "^4.1.6",
     "react-native-linear-gradient": "2.5.6",
     "react-native-svg": "13.7.0",
-    "lodash": "4.17.21",
-    "@react-native-async-storage/async-storage": "https://github.com/blitzstudios/async-storage.git#release/1.1"
+    "react-native-udp": "^4.1.6"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",

--- a/template/patches/@callstack+repack+2.5.3.patch
+++ b/template/patches/@callstack+repack+2.5.3.patch
@@ -1,0 +1,15 @@
+diff --git a/node_modules/@callstack/repack/dist/modules/ScriptManager/ScriptManager.js b/node_modules/@callstack/repack/dist/modules/ScriptManager/ScriptManager.js
+index af3b789..176870b 100644
+--- a/node_modules/@callstack/repack/dist/modules/ScriptManager/ScriptManager.js
++++ b/node_modules/@callstack/repack/dist/modules/ScriptManager/ScriptManager.js
+@@ -249,10 +249,6 @@ export class ScriptManager extends EventEmitter {
+       this.emit('resolved', script.toObject());
+       return script;
+     } catch (error) {
+-      this.handleError(error, '[ScriptManager] Failed while resolving script locator:', {
+-        scriptId,
+-        caller
+-      });
+       return new Promise(resolve => {
+         resolve(null);
+       });

--- a/template/src/Sleeper/Components.tsx
+++ b/template/src/Sleeper/Components.tsx
@@ -10,7 +10,14 @@ import {Federated} from '@callstack/repack/client';
 import {Context} from './Types';
 
 const _SleeperModule = React.lazy(() =>
-  Federated.importModule('sleeper', 'index'),
+  Federated.importModule('sleeper', 'index').catch(() => ({
+    default: props => {
+      console.log(
+        `[Sleeper] Failed to load <${props?.component}>. Check connection to the app.`,
+      );
+      return <View />;
+    },
+  })),
 );
 
 type ButtonProps = {

--- a/template/yarn.lock
+++ b/template/yarn.lock
@@ -2363,6 +2363,13 @@ avvio@^7.1.2:
     fastq "^1.6.1"
     queue-microtask "^1.1.2"
 
+axios@0.15.3:
+  version "0.15.3"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.15.3.tgz#2c9d638b2e191a08ea1d6cc988eadd6ba5bdc053"
+  integrity sha512-w3/VNaraEcDri16lbemQWQGKfaFk9O0IZkzKlLeF5r6WWDv9TkcXkP+MWkRK8FbxwfozY/liI+qtvhV295t3HQ==
+  dependencies:
+    follow-redirects "1.0.0"
+
 babel-core@^7.0.0-bridge.0:
   version "7.0.0-bridge.0"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-7.0.0-bridge.0.tgz#95a492ddd90f9b4e9a4a1da14eb335b87b634ece"
@@ -3987,6 +3994,13 @@ flow-parser@^0.121.0:
   version "0.121.0"
   resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.121.0.tgz#9f9898eaec91a9f7c323e9e992d81ab5c58e618f"
   integrity sha512-1gIBiWJNR0tKUNv8gZuk7l9rVX06OuLzY9AoGio7y/JT4V1IZErEMEq2TJS+PFcw/y0RshZ1J/27VfK1UQzYVg==
+
+follow-redirects@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.0.0.tgz#8e34298cbd2e176f254effec75a1c78cc849fd37"
+  integrity sha512-7s+wBk4z5xTwVJuozRBAyRofWKjD3uG2CUjZfZTrw9f+f+z8ZSxOjAqfIDLtc0Hnz+wGK2Y8qd93nGGjXBYKsQ==
+  dependencies:
+    debug "^2.2.0"
 
 for-in@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
### Description

Previously, when a user ran this template project locally but was not successfully connected to a running Sleeper app, we would get several generic errors when trying to load Sleeper components.

This commit fixes that issue and adds more useful logging information.

### How To Test

1. Start up the project without being connected to a running Sleeper app.
2. Render a `<Sleeper.X>` component (where X is one of the supported component types)
3. Make sure no crash occurs.
4. Connect to the running Sleeper app.
5. Observe the component rendering as expected.

### Screenshots/Video

One error that would often appear: 
```
[ScriptManager] Failed to load script: [ScriptDownloadFailure] {scriptId: 'sleeper', caller: undefined, locator: {…}, cache: true} {originalError: Error: Unknown error from a native module
…omiseMethodWrapper [as loadScript] (/User…}
```

New messaging:
![Screen Shot 2023-03-09 at 5 22 05 PM](https://user-images.githubusercontent.com/61988202/224199031-8ee663b3-b7fa-4385-b3ec-cde7b2f4839a.png)
